### PR TITLE
Workaround (stable on the ground)

### DIFF
--- a/rs_ctrl/service/piid.c
+++ b/rs_ctrl/service/piid.c
@@ -94,5 +94,14 @@ void piid_run(float u_ctrl[3], float gyro[3], float rc[3], float dt)
 {
    FOR_N(i, 3)
       u_ctrl[i] = pid_control(&ctrl[i], rc[i] - gyro[i], 0.0, dt);
+   
+   //workaround allowing quadcopter to be stable on the ground
+   double gyro_noise_value = 0.0005; //must be set very carefully  
+      
+   if ((abs(rc[0]-gyro[0]) < gyro_noise_value) && (abs(rc[1]-gyro[1]) < gyro_noise_value))
+    {
+     tsfloat_set(&ctrl[0].sum_error, 0.0);
+     tsfloat_set(&ctrl[1].sum_error, 0.0);
+    }
 }
 


### PR DESCRIPTION
Because of the small offset of a gyro, quadcopter becomes not stable during static standing on the ground. rs_ctrl service (using piid controller) tries to put a quadcopter to the desired position, according to gyro values. But in the ground, in static position, nothing is changing. That's why piid controller becomes unstable and provides too much torques to the motors, which can lead to a turnover of a quadcopter. 
Workaround for this: to put some noise thresholds to a controller.
